### PR TITLE
Date format

### DIFF
--- a/JSONUtil.cfc
+++ b/JSONUtil.cfc
@@ -1,4 +1,5 @@
 <!---
+https://github.com/CFCommunity/jsonutil
 
 Copyright 2009 Nathan Mische
 

--- a/JSONUtil.cfc
+++ b/JSONUtil.cfc
@@ -366,7 +366,11 @@ limitations under the License.
 
 		<!--- DATE --->
 		<cfelseif IsDate(_data)>
-			<cfreturn '"#DateFormat(_data, "mmmm, dd yyyy")# #TimeFormat(_data, "HH:mm:ss")#"' />
+			<cfif len(_data) EQ 10>
+				<cfreturn '"' & dateFormat(_data, "yyyy-mm-dd") & '"'>
+			<cfelse>
+				<cfreturn '"' & dateFormat(_data, "yyyy-mm-dd") & 'T' & timeFormat(_data, "HH:mm:ss.l") & '"'>
+			</cfif>
 
 		<!--- STRING --->
 		<cfelseif IsSimpleValue(_data)>


### PR DESCRIPTION
*Warning:* This is a breaking change, compared to previous behavior.
Formats dates as ISO8601 (`2018-09-25` or `2018-09-25T02:57:07Z`)

The format used by Date's toJSON function, and expected by moment.js
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON